### PR TITLE
feat: support annotation on top of top-layer dialog

### DIFF
--- a/src/helpers/knowledge/db.json
+++ b/src/helpers/knowledge/db.json
@@ -86,5 +86,20 @@
         }
       }
     ]
+  },
+  "github.com": {
+    "rules": [
+      {
+        "regexes": [
+          ".*"
+        ],
+        "knowledge": {
+          "notes": [
+            "You can open the account menu by clicking the user's avatar on the top right. You can find and manage current user's profile, repositories, projects, organizations, etc. in the menu.",
+            "To invite a member to an organization or a team, you need to first click \"Invite member\" or \"Invite someone\". When you see the dialog, type in the input to search by username or email, then click the button appear under the input that says \"[name] invite to [org]\". Please note that this does not actually send the invite: it only adds the user to the selection. You must then click the green \"Invite\" button to send the invitation."
+          ]
+        }
+      }
+    ]
   }
 }

--- a/src/pages/content/drawLabels.ts
+++ b/src/pages/content/drawLabels.ts
@@ -13,6 +13,10 @@ styleElem.innerHTML = `
   z-index: 99999999;
   top: 0;
   left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: unset;
+  border: none;
 }
 ._label_overlay_2 {
   position: absolute;
@@ -294,6 +298,8 @@ function getLabelData(
     }
   }
   elements.forEach((elem) => {
+    // skip if the element is disabled
+    if (elem.getAttribute("disabled") != null) return;
     // skip specialElements
     if (elem.hasAttribute(WEB_WAND_LABEL_ATTRIBUTE_NAME)) return;
     // skip if the element is already touched
@@ -329,10 +335,13 @@ export function addLabelsToDom(data: LabelDataWithElement[]) {
   // wrapper element
   const wrapper = document.createElement("div");
   wrapper.classList.add("_label_overlay_wrapper");
+  wrapper.popover = "manual";
   data.forEach(({ element, label }, index) => {
     drawLabel(wrapper, element, label, baseZIndex + data.length - index);
   });
   document.body.appendChild(wrapper);
+  // this does not exist on Firefox yet
+  wrapper.togglePopover && wrapper.togglePopover();
 }
 
 export function removeLabels() {


### PR DESCRIPTION
Some website, such as github, is using dialog https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
The `popover` attribute on this kind of element is going to be top of everything no matter how big the z-index is. To make annotation work, our overlay wrapper must also be a popover

Also in this PR: some notes for github
