### PR TITLE
UX updates on TaskUI textarea

### DIFF
--- a/src/common/AutosizeTextarea.tsx
+++ b/src/common/AutosizeTextarea.tsx
@@ -11,7 +11,7 @@ const AutosizeTextarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         w="100%"
         resize="none"
         ref={ref}
-        minRows={1}
+        minRows={4}
         as={ResizeTextarea}
         {...props}
       />

--- a/src/common/TaskUI.tsx
+++ b/src/common/TaskUI.tsx
@@ -17,6 +17,7 @@ import VoiceButton from "./VoiceButton";
 import TaskHistory from "./TaskHistory";
 import TaskStatus from "./TaskStatus";
 import RecommendedTasks from "./RecommendedTasks";
+import AutosizeTextarea from "./AutosizeTextarea";
 
 function ActionExecutor() {
   const state = useAppState((state) => ({
@@ -102,12 +103,12 @@ const TaskUI = () => {
 
   return (
     <>
-      <Textarea
+      <AutosizeTextarea
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus
         placeholder="Try telling WebWand to do something..."
         value={state.instructions || ""}
-        disabled={taskInProgress || state.isListening}
+        isDisabled={taskInProgress || state.isListening}
         onChange={(e) => state.setInstructions(e.target.value)}
         mb={2}
         onKeyDown={onKeyDown}


### PR DESCRIPTION
- the textarea is now auto-sized 
- instead of enter to run task, use shift+enter instead (to encourage longer prompt)
- textarea is disabled only when listening instead of always disabled during voice mode